### PR TITLE
Bump jQuery from 1.9.1 to 3.5.0 in /JS/FavoritesWeb

### DIFF
--- a/JS/FavoritesWeb/packages.config
+++ b/JS/FavoritesWeb/packages.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="jQuery" version="1.9.1" targetFramework="net45" />
+  <package id="jQuery" version="3.5.0" targetFramework="net45" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.Office.js" version="1.1.0.9" targetFramework="net45" />


### PR DESCRIPTION
Bumps jQuery from 1.9.1 to 3.5.0.

---
updated-dependencies:
- dependency-name: jQuery dependency-type: direct:production ...

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
